### PR TITLE
Remove reference to NServiceBus from contracts assembly

### DIFF
--- a/src/LegacyApp.Api/Controllers/OrderController.cs
+++ b/src/LegacyApp.Api/Controllers/OrderController.cs
@@ -22,13 +22,18 @@ public class OrderController :
     [HttpPost(Name = "SubmitOrder")]
     public async Task<IActionResult> PostOrder(OrderModel order, [FromServices] IMessageSession session)
     {
-        _logger.LogInformation("Sending SubmitOrder command, OrderNumber is {OrderNumber}", order.OrderNumber);
+        var requestKey = Guid.NewGuid().ToString();
+
+        SendOptions sendOptions = new();
+        sendOptions.SetHeader("X-Request-Key", requestKey);
+
+        _logger.LogInformation("Sending SubmitOrder command, RequestKey is {RequestKey}, OrderNumber is {OrderNumber}", requestKey, order.OrderNumber);
 
         await session.Send(new SubmitOrder
         {
             OrderNumber = order.OrderNumber,
             Amount = order.Amount
-        });
+        }, sendOptions);
 
         return Accepted();
     }

--- a/src/LegacyApp.Api/Controllers/OrderController.cs
+++ b/src/LegacyApp.Api/Controllers/OrderController.cs
@@ -1,3 +1,5 @@
+using LegacyApp.Contracts.Commands;
+
 namespace LegacyApp.Api.Controllers;
 
 using Contracts;
@@ -20,18 +22,13 @@ public class OrderController :
     [HttpPost(Name = "SubmitOrder")]
     public async Task<IActionResult> PostOrder(OrderModel order, [FromServices] IMessageSession session)
     {
-        var requestKey = Guid.NewGuid().ToString();
-
-        SendOptions sendOptions = new();
-        sendOptions.SetHeader("X-Request-Key", requestKey);
-
-        _logger.LogInformation("Sending SubmitOrder command, RequestKey is {RequestKey}, OrderNumber is {OrderNumber}", requestKey, order.OrderNumber);
+        _logger.LogInformation("Sending SubmitOrder command, OrderNumber is {OrderNumber}", order.OrderNumber);
 
         await session.Send(new SubmitOrder
         {
             OrderNumber = order.OrderNumber,
             Amount = order.Amount
-        }, sendOptions);
+        });
 
         return Accepted();
     }

--- a/src/LegacyApp.Api/LegacyApp.Api.csproj
+++ b/src/LegacyApp.Api/LegacyApp.Api.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="7.8.0" />
     <PackageReference Include="NServiceBus.Extensions.DependencyInjection" Version="1.1.0" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.1.0" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.4.0" />

--- a/src/LegacyApp.Api/Program.cs
+++ b/src/LegacyApp.Api/Program.cs
@@ -19,7 +19,7 @@ builder.Host.UseNServiceBus(_ =>
         .DefiningEventsAs(t => t.Namespace != null && t.Namespace.StartsWith("LegacyApp.Contracts.Events"));
 
     var transport = endpointConfiguration.UseTransport<RabbitMQTransport>();
-    transport.ConnectionString("host=192.168.1.25");
+    transport.ConnectionString("host=localhost;username=guest;password=guest;virtualhost=/");
 
     transport.UseConventionalRoutingTopology(QueueType.Classic);
 

--- a/src/LegacyApp.Components/LegacyApp.Components.csproj
+++ b/src/LegacyApp.Components/LegacyApp.Components.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="..\LegacyApp.Contracts\LegacyApp.Contracts.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="7.8.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/LegacyApp.Components/OrderSubmissionAcceptedHandler.cs
+++ b/src/LegacyApp.Components/OrderSubmissionAcceptedHandler.cs
@@ -13,7 +13,9 @@ public class OrderSubmissionAcceptedHandler :
 
     public Task Handle(OrderSubmissionAccepted message, IMessageHandlerContext context)
     {
-        _log.InfoFormat("Received OrderSubmissionAccepted, OrderNumber = {OrderNumber}", message.OrderNumber);
+        _log.InfoFormat("Received OrderSubmissionAccepted, OrderNumber = {OrderNumber}, RequestKey = {RequestKey}",
+            message.OrderNumber,
+            context.MessageHeaders.ContainsKey("X-Request-Key") ? context.MessageHeaders["X-Request-Key"] : "NA");
 
         return Task.CompletedTask;
     }

--- a/src/LegacyApp.Components/OrderSubmissionAcceptedHandler.cs
+++ b/src/LegacyApp.Components/OrderSubmissionAcceptedHandler.cs
@@ -1,9 +1,10 @@
+using LegacyApp.Contracts.Events;
+
 namespace LegacyApp.Components;
 
 using Contracts;
 using NServiceBus;
 using NServiceBus.Logging;
-
 
 public class OrderSubmissionAcceptedHandler :
     IHandleMessages<OrderSubmissionAccepted>
@@ -12,9 +13,7 @@ public class OrderSubmissionAcceptedHandler :
 
     public Task Handle(OrderSubmissionAccepted message, IMessageHandlerContext context)
     {
-        _log.InfoFormat("Received OrderSubmissionAccepted, OrderNumber = {OrderNumber}, RequestKey = {RequestKey}",
-            message.OrderNumber,
-            context.MessageHeaders.ContainsKey("X-Request-Key") ? context.MessageHeaders["X-Request-Key"] : "NA");
+        _log.InfoFormat("Received OrderSubmissionAccepted, OrderNumber = {OrderNumber}", message.OrderNumber);
 
         return Task.CompletedTask;
     }

--- a/src/LegacyApp.Components/OrderSubmittedHandler.cs
+++ b/src/LegacyApp.Components/OrderSubmittedHandler.cs
@@ -1,4 +1,6 @@
-﻿namespace LegacyApp.Components;
+﻿using LegacyApp.Contracts.Events;
+
+namespace LegacyApp.Components;
 
 using Contracts;
 using NServiceBus;

--- a/src/LegacyApp.Components/SubmitOrderHandler.cs
+++ b/src/LegacyApp.Components/SubmitOrderHandler.cs
@@ -1,3 +1,6 @@
+using LegacyApp.Contracts.Commands;
+using LegacyApp.Contracts.Events;
+
 namespace LegacyApp.Components;
 
 using Contracts;
@@ -25,16 +28,11 @@ public class SubmitOrderHandler :
         //     throw new Exception("Transient Failure");
         // }
 
-        var requestKey = context.MessageHeaders["X-Request-Key"];
+        _log.InfoFormat("Replying with OrderSubmissionAccepted and publishing OrderSubmitted, OrderNumber = {OrderNumber}",
+            message.OrderNumber);
 
-        _log.InfoFormat("Replying with OrderSubmissionAccepted and publishing OrderSubmitted, OrderNumber = {OrderNumber}, RequestKey = {RequestKey}",
-            message.OrderNumber, requestKey);
-
-        ReplyOptions replyOptions = new();
-        replyOptions.SetHeader("X-Request-Key", requestKey);
-        
         return Task.WhenAll(
             context.Publish(new OrderSubmitted { OrderNumber = message.OrderNumber }),
-            context.Reply(new OrderSubmissionAccepted { OrderNumber = message.OrderNumber }, replyOptions));
+            context.Reply(new OrderSubmissionAccepted { OrderNumber = message.OrderNumber }));
     }
 }

--- a/src/LegacyApp.Components/SubmitOrderHandler.cs
+++ b/src/LegacyApp.Components/SubmitOrderHandler.cs
@@ -28,11 +28,16 @@ public class SubmitOrderHandler :
         //     throw new Exception("Transient Failure");
         // }
 
-        _log.InfoFormat("Replying with OrderSubmissionAccepted and publishing OrderSubmitted, OrderNumber = {OrderNumber}",
-            message.OrderNumber);
+        var requestKey = context.MessageHeaders["X-Request-Key"];
+
+        _log.InfoFormat("Replying with OrderSubmissionAccepted and publishing OrderSubmitted, OrderNumber = {OrderNumber}, RequestKey = {RequestKey}",
+            message.OrderNumber, requestKey);
+
+        ReplyOptions replyOptions = new();
+        replyOptions.SetHeader("X-Request-Key", requestKey);
 
         return Task.WhenAll(
             context.Publish(new OrderSubmitted { OrderNumber = message.OrderNumber }),
-            context.Reply(new OrderSubmissionAccepted { OrderNumber = message.OrderNumber }));
+            context.Reply(new OrderSubmissionAccepted { OrderNumber = message.OrderNumber }, replyOptions));
     }
 }

--- a/src/LegacyApp.Contracts/Commands/SubmitOrder.cs
+++ b/src/LegacyApp.Contracts/Commands/SubmitOrder.cs
@@ -1,0 +1,7 @@
+﻿namespace LegacyApp.Contracts.Commands;
+
+public record SubmitOrder
+{
+    public string? OrderNumber { get; init; }
+    public decimal? Amount { get; init; }
+}

--- a/src/LegacyApp.Contracts/Events/OrderSubmissionAccepted.cs
+++ b/src/LegacyApp.Contracts/Events/OrderSubmissionAccepted.cs
@@ -1,0 +1,7 @@
+namespace LegacyApp.Contracts.Events;
+
+public record OrderSubmissionAccepted
+{
+    public string? OrderNumber { get; init; }
+    public decimal? Amount { get; init; }
+}

--- a/src/LegacyApp.Contracts/Events/OrderSubmitted.cs
+++ b/src/LegacyApp.Contracts/Events/OrderSubmitted.cs
@@ -1,0 +1,7 @@
+namespace LegacyApp.Contracts.Events;
+
+public record OrderSubmitted
+{
+    public string? OrderNumber { get; init; }
+    public decimal? Amount { get; init; }
+}

--- a/src/LegacyApp.Contracts/LegacyApp.Contracts.csproj
+++ b/src/LegacyApp.Contracts/LegacyApp.Contracts.csproj
@@ -6,8 +6,4 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="7.7.4" />
-  </ItemGroup>
-
 </Project>

--- a/src/NewApp.Worker/OrderSubmittedConsumer.cs
+++ b/src/NewApp.Worker/OrderSubmittedConsumer.cs
@@ -1,3 +1,5 @@
+using LegacyApp.Contracts.Events;
+
 namespace NewApp.Worker;
 
 using LegacyApp.Contracts;

--- a/src/NewApp.Worker/Program.cs
+++ b/src/NewApp.Worker/Program.cs
@@ -21,7 +21,7 @@ var host = Host.CreateDefaultBuilder(args)
         services.AddOptions<RabbitMqTransportOptions>()
             .Configure(options =>
             {
-                options.Host = "192.168.1.25";
+                options.Host = "localhost";
             });
     })
     .Build();

--- a/src/NewApp.Worker/Program.cs
+++ b/src/NewApp.Worker/Program.cs
@@ -1,6 +1,5 @@
 using MassTransit;
 using NewApp.Worker;
-using NServiceBus;
 
 var host = Host.CreateDefaultBuilder(args)
     .UseMassTransit((_, x) =>
@@ -12,9 +11,6 @@ var host = Host.CreateDefaultBuilder(args)
 
         x.UsingRabbitMq((context, cfg) =>
         {
-            cfg.Publish<IEvent>(p => p.Exclude = true);
-            cfg.Publish<IMessage>(p => p.Exclude = true);
-
             cfg.UseNServiceBusJsonSerializer();
 
             cfg.ConfigureEndpoints(context);
@@ -25,7 +21,7 @@ var host = Host.CreateDefaultBuilder(args)
         services.AddOptions<RabbitMqTransportOptions>()
             .Configure(options =>
             {
-                options.Host = "localhost";
+                options.Host = "192.168.1.25";
             });
     })
     .Build();

--- a/src/NewApp.Worker/SubmitOrderConsumer.cs
+++ b/src/NewApp.Worker/SubmitOrderConsumer.cs
@@ -6,7 +6,6 @@ namespace NewApp.Worker;
 using LegacyApp.Contracts;
 using MassTransit;
 
-
 public class SubmitOrderConsumer :
     IConsumer<SubmitOrder>
 {
@@ -19,10 +18,11 @@ public class SubmitOrderConsumer :
 
     public Task Consume(ConsumeContext<SubmitOrder> context)
     {
-        _logger.LogInformation("Received SubmitOrder, OrderNumber = {OrderNumber}", context.Message.OrderNumber);
+        var requestKey = context.Headers.Get<string>("X-Request-Key");
 
-        _logger.LogInformation("Responding with OrderSubmissionAccepted and publishing OrderSubmitted, OrderNumber = {OrderNumber}",
-            context.Message.OrderNumber);
+        _logger.LogInformation(
+            "Responding with OrderSubmissionAccepted and publishing OrderSubmitted, OrderNumber = {OrderNumber}, RequestKey = {RequestKey}",
+            context.Message.OrderNumber, requestKey);
 
         return Task.WhenAll(
             context.Publish(new OrderSubmitted { OrderNumber = context.Message.OrderNumber }),

--- a/src/NewApp.Worker/SubmitOrderConsumer.cs
+++ b/src/NewApp.Worker/SubmitOrderConsumer.cs
@@ -1,3 +1,6 @@
+using LegacyApp.Contracts.Commands;
+using LegacyApp.Contracts.Events;
+
 namespace NewApp.Worker;
 
 using LegacyApp.Contracts;
@@ -18,10 +21,8 @@ public class SubmitOrderConsumer :
     {
         _logger.LogInformation("Received SubmitOrder, OrderNumber = {OrderNumber}", context.Message.OrderNumber);
 
-        var requestKey = context.Headers.Get<string>("X-Request-Key");
-
-        _logger.LogInformation("Responding with OrderSubmissionAccepted and publishing OrderSubmitted, OrderNumber = {OrderNumber}, RequestKey = {RequestKey}",
-            context.Message.OrderNumber, requestKey);
+        _logger.LogInformation("Responding with OrderSubmissionAccepted and publishing OrderSubmitted, OrderNumber = {OrderNumber}",
+            context.Message.OrderNumber);
 
         return Task.WhenAll(
             context.Publish(new OrderSubmitted { OrderNumber = context.Message.OrderNumber }),


### PR DESCRIPTION
This pull request removes the `ICommand` and `IEvent` interfaces from the messages in the contracts assembly.
As a result the NServiceBus reference can be removed and the MassTransit project doesn't require _any reference_ to NServiceBus.